### PR TITLE
Add error check for pvpython executable

### DIFF
--- a/separate_vestec_data.sh
+++ b/separate_vestec_data.sh
@@ -11,6 +11,11 @@ fi
 
 PV_PYTHON="./ttk-paraview/build/bin/pvpython"
 
+if [ ! -x "${PV_PYTHON}" ]; then
+  echo "Error: pvpython not found or not executable at: ${PV_PYTHON}" >&2
+  exit 1
+fi
+
 echo "Running 002.py..."
 "${PV_PYTHON}" 002.py
 


### PR DESCRIPTION
Hello Sebastien Tchitcheck,

This PR proposes a small improvement to the script that separates the `vestec` data.
It adds a check to ensure the `pvpython` executable exists and is executable.

